### PR TITLE
Add workflow config for PR preview to netlify

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - build-jupyterbook
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -35,15 +35,15 @@ jobs:
         if: success() || failure()
         shell: bash -el {0}
         run: conda run -n bookbuilder jupyter-book build .
-      - name: Upload artifact to pass to GitHub Pages
-        if: success() || failure()
+      - name: Upload artifact to pass to GitHub Pages (if on main branch)
+        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: _build/html
-  deploy:
-    name: Deploy to GitHub Pages
+  deploy-main:
+    name: Deploy main branch to GitHub Pages
     needs: build
-    if: success() || failure()
+    if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
         pages: write      # to deploy to Pages
@@ -58,3 +58,16 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+  deploy-preview:
+    name: Deploy PR preview to Netlify
+    needs: build
+    if: ${{ github.event.pull_request && (success() || failure()) }}
+    uses: nwtgck/actions-netlify@v3.0
+    with:
+      publish-dir: './_build/html'
+        production-deploy: false
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        enable-pull-request-comment: true
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_API_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,16 @@ jobs:
         if: success() || failure()
         shell: bash -el {0}
         run: conda run -n bookbuilder jupyter-book build .
-      - name: Upload artifact to pass to GitHub Pages or  Netlify
-        if: success() || failure()
+      - name: Upload artifact to pass to GitHub Pages
+        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
         uses: actions/upload-pages-artifact@v3
         with:
-          name: github-pages
+          path: _build/html
+      - name: Upload artifact to pass to Netlify
+        if: ${{ github.event.pull_request && (success() || failure()) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-preview
           path: _build/html
   deploy-main:
     name: Deploy main branch to GitHub Pages
@@ -68,7 +73,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: github-pages
+          name: html-preview
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: html-preview
+      - name: (Debug)
+        run: ls -R
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,9 @@ jobs:
     uses: nwtgck/actions-netlify@v3.0
     with:
       publish-dir: './_build/html'
-        production-deploy: false
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        enable-pull-request-comment: true
-      env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_API_ID }}
+      production-deploy: false
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      enable-pull-request-comment: true
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_API_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,11 @@ jobs:
         if: success() || failure()
         shell: bash -el {0}
         run: conda run -n bookbuilder jupyter-book build .
-      - name: Upload artifact to pass to GitHub Pages (if on main branch)
-        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
+      - name: Upload artifact to pass to GitHub Pages or  Netlify
+        if: success() || failure()
         uses: actions/upload-pages-artifact@v3
         with:
+          name: github-pages
           path: _build/html
   deploy-main:
     name: Deploy main branch to GitHub Pages
@@ -64,10 +65,14 @@ jobs:
     if: ${{ github.event.pull_request && (success() || failure()) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0
         with:
-          publish-dir: './_build/html'
+          publish-dir: _build/html
           production-deploy: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-pull-request-comment: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,12 +62,15 @@ jobs:
     name: Deploy PR preview to Netlify
     needs: build
     if: ${{ github.event.pull_request && (success() || failure()) }}
-    uses: nwtgck/actions-netlify@v3.0
-    with:
-      publish-dir: './_build/html'
-      production-deploy: false
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      enable-pull-request-comment: true
-    env:
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_API_ID }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: './_build/html'
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-pull-request-comment: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_API_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy GitHub Pages
+name: Build and Deploy Jupyter-Book
 
 on:
   push:
@@ -73,4 +73,4 @@ jobs:
           enable-pull-request-comment: true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_API_ID }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: html-preview
-      - name: (Debug)
-        run: ls -R
+          path: _build/html
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0
         with:


### PR DESCRIPTION
This should make any PR trigger a build and preview to Netlify.

Notebooks are re-executed according to the state of that branch, and a new jupyter-book website is generated and published to a temporary URL on Netlify.

i.e. This PR was previewed at https://66bc9a7e7cf6ac96f876edcf--igrf14eval.netlify.app

The workflow works like:
1. Execute the notebooks and use jupyter-book to generate the website content (html)
2. a) If this is a PR: push that html to a unique URL on netlify
    b) If this is the main branch: push that html to GitHub Pages

Step 1 reports a failure because the notebooks do not execute completely, though the corresponding html is still generated. Step 2a still reports a failure here because it did not successfully add the comment to the PR, which is now fixed by https://github.com/IAGA-VMOD/IGRF14eval/pull/9/commits/8678d1dde995f27438b0f3fc35e76a75b780a0ac  (see https://github.com/IAGA-VMOD/IGRF14eval/pull/9 for an example)

![image](https://github.com/user-attachments/assets/546990a6-408c-4dd0-a3eb-424c1efa51f8)

Netlify is used for the previews for convenience over GitHub pages as it is not yet easy to generate previews from forks on GH pages

GH Actions is authorised to push to the Netlify site by adding the secrets NETLIFY_AUTH_TOKEN & NETLIFY_SITE_ID to https://github.com/IAGA-VMOD/IGRF14eval/settings/secrets/actions