### PR TITLE
Add config for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "name": "IGRF-14 Evaluation",
+    "image": "mcr.microsoft.com/vscode/devcontainers/miniconda",
+    "features": {
+      "ghcr.io/devcontainers/features/conda:1": {
+        "version": "latest"
+      }
+    },
+    "postCreateCommand": "conda create --name igrf --file binder/lockfiles/conda-linux-64.lock && conda activate igrf",
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-python.python",
+          "ms-toolsai.jupyter"
+        ]
+      }
+    }
+  }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Build Jupyter Book


### PR DESCRIPTION
Adding the devcontainer configuration lets the repo work on GitHub Codespaces - for now it just sets up the `igrf` conda environment allowing the notebooks to be run there. Codespaces can be accessed and configured via https://github.com/IAGA-VMOD/IGRF14eval/codespaces

Once this PR is merged then the `main` Codespace should be accessible at https://github.dev/IAGA-VMOD/IGRF14eval

...  but I think it's something that people need to enable on their own GitHub account before it will work